### PR TITLE
Adding ability to push data across XbeeTX with N.io

### DIFF
--- a/tests/test_xbee_tx_block.py
+++ b/tests/test_xbee_tx_block.py
@@ -50,7 +50,7 @@ class TestXBeeTX(NIOBlockTestCase):
             'tx',
             frame_id=b'\x01',
             dest_addr=b'\xFF\xFF',
-            data=b'{"iama": "signal"}')
+            data=b"{'iama': 'signal'}")
         self.assertFalse(len(self.last_notified[DEFAULT_TERMINAL]))
         blk.stop()
 


### PR DESCRIPTION
Added a data property to XBee to allow data to be input to the XBeeTX block and sent over Xbee. The old code used json.dumps to encode the data, but this added extra quotes around the data. The current scheme seems to work well to send any arbitrary data.
